### PR TITLE
chore: bump default AMI from AL2 to AL2023

### DIFF
--- a/cdk/settings.py
+++ b/cdk/settings.py
@@ -73,7 +73,7 @@ class StackSettings(BaseSettings):
     # If using SSM to resolve the AMI ID, prefix with `resolve:ssm`.
     # MCP_AMI_ID: str = "resolve:ssm:/mcp/amis/aml2023-ecs"
     MCP_AMI_ID: str = (
-        "resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
+        "resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
     )
 
     # Cluster instance classes


### PR DESCRIPTION
Bumps our default (non-MCP) AMI reference to use Amazon Linux 2023

Reference: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/retrieve-ecs-optimized_AMI.html